### PR TITLE
Update issuer names in verify_crt()

### DIFF
--- a/letsencrypt_remote.py
+++ b/letsencrypt_remote.py
@@ -659,7 +659,10 @@ def verify_crt(crt, domains):
     if issuer in ["happy hacker fake CA",
                   "Fake LE Intermediate X1"]:
         click.echo(click.style("Certificate issued by staging CA!", fg="red"))
-    elif issuer == "Let's Encrypt Authority X3":
+    elif issuer in ["Let's Encrypt Authority X1",
+                    "Let's Encrypt Authority X2",
+                    "Let's Encrypt Authority X3",
+                    "Let's Encrypt Authority X4"]:
         click.echo(click.style("Certificate issued by: %s" % issuer, fg="green"))
     else:
         click.echo(click.style("Unknown CA: %s" % issuer, fg="red"))

--- a/letsencrypt_remote.py
+++ b/letsencrypt_remote.py
@@ -656,7 +656,8 @@ def verify_crt(crt, domains):
             OpenSSL.crypto.FILETYPE_PEM, f.read())
     issuer = dict(cert.get_issuer().get_components()).get(
         b'CN', b'unknown').decode('ascii')
-    if issuer == 'happy hacker fake CA':
+    if issuer in ["happy hacker fake CA",
+                  "Fake LE Intermediate X1"]:
         click.echo(click.style("Certificate issued by staging CA!", fg="red"))
     elif issuer == "Let's Encrypt Authority X3":
         click.echo(click.style("Certificate issued by: %s" % issuer, fg="green"))

--- a/letsencrypt_remote.py
+++ b/letsencrypt_remote.py
@@ -655,7 +655,7 @@ def verify_crt(crt, domains):
         cert = OpenSSL.crypto.load_certificate(
             OpenSSL.crypto.FILETYPE_PEM, f.read())
     issuer = dict(cert.get_issuer().get_components()).get(
-        b'CN', b'unkown').decode('ascii')
+        b'CN', b'unknown').decode('ascii')
     if issuer == 'happy hacker fake CA':
         click.echo(click.style("Certificate issued by staging CA!", fg="red"))
     elif issuer == "Let's Encrypt Authority X3":


### PR DESCRIPTION
Just let me know if you want any edits to these or if you want any of the changes dropped from the PR.

**Staging Environment**

When the intermediate certificates changed a while back, the issuer also changed for the staging server:
* old: issuer="happy hacker fake CA"
* new: "Fake LE Intermediate X1"

This showed up as ````Unknown CA: Fake LE Intermediate X1```` rather than ````Certificate issued by staging CA!```` in the output when running against the staging server.

Also mentioned in the announcement about a change of intermediates:
* https://community.letsencrypt.org/t/upcoming-intermediate-changes/13106

New fake CA cert is listed on this page
* https://letsencrypt.org/docs/staging-environment/

Current fake intermediate cert details are here:
* https://ssl-tools.net/subjects/c29c130a07d1ff36475f8766b701c13205df6527

**Production Environment**

I've also added all production (previous and current) intermediate certs to the list of valid issuers.  Based on this page:
* https://letsencrypt.org/certificates/

