### PR TITLE
verify_domains: compute symmetric diff between csr and command line domains

### DIFF
--- a/letsencrypt_remote.py
+++ b/letsencrypt_remote.py
@@ -204,7 +204,7 @@ def verify_domains(cert_or_req, domains):
             x.strip().replace('DNS:', '')
             for x in str(ext).split(',')]
         names = names.union(alt_names)
-    unmatched = set(domains).difference(names)
+    unmatched = set(domains).symmetric_difference(names)
     if unmatched:
         click.echo(click.style(
             "Unmatched alternate names %s" % ', '.join(unmatched), fg="red"))


### PR DESCRIPTION
Computing the set difference only catches when the csr is missing a domain
that is listed on the command line.  It fails to catch when the csr has
one or more *extra* domains than appear on the command line.  This results
in one or more extra hosts being listed in the csr than are on the command
line.

This is bad since it could either issue a cert with more domains than you
asked for if the extra domains pass their challenge, or it can also fail
if the extra (unwanted) domains fail their challenge.

Changed to use symmetric_difference which will catch any domains that are
in either set but not in both.

Example:
````
letsencrypt-remote -s a.example.org b.example.org oops.example.org
````
Assume oops.example.org fails challenge because it was a typo
````
letsencrypt-remote -s a.example.org b.example.org
````
This fails since the csr still contains oops.example.org which has not answered the challenge.
