### PR TITLE
FIX: Also accept a 200 for the Nonce request

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+0.9.1 - Unreleased
+------------------
+
+* Accept return code 200 for nonce request.
+  [witsch]
+
+
 0.9.0 - 2020-06-14
 ------------------
 

--- a/src/certsling/acme.py
+++ b/src/certsling/acme.py
@@ -40,7 +40,7 @@ class ACME:
     def ensure_nonce(self):
         if self.acme_uris.session.nonce is None:
             res = self.acme_uris.new_nonce()
-            if res.status_code != 204:
+            if res.status_code not in (200, 204):
                 fatal_response("Bad newNonce response", res)
 
     def finalize_order(self, uri, der_data):


### PR DESCRIPTION
I otherwise kept getting…
```
⋮
Preparing challenges for zitc.de, mail.zitc.de.
Bad newNonce response: 200 OK
{}
Server: nginx
Date: Fri, 07 Aug 2020 23:24:43 GMT
Connection: keep-alive
Cache-Control: public, max-age=0, no-cache
Link: <https://acme-staging-v02.api.letsencrypt.org/directory>;rel="index"
Replay-Nonce: 0001rJ7dlJbzGmA9TjfLqX_p9N…-w
X-Frame-Options: DENY
Strict-Transport-Security: max-age=604800
```